### PR TITLE
deploy now button

### DIFF
--- a/javascript/src/geo-redirect/README.md
+++ b/javascript/src/geo-redirect/README.md
@@ -1,6 +1,6 @@
 ⏮️ Back to javascript [README.md](../../README.md)
 
-# Geo Redirect
+# Geo Redirect <a href="https://portal.gcore.com/fastedge/create-template-app/6" style="display: inline-block; background-color: #ff4c00; color: white; padding: 5px 14px; text-decoration: none; font-weight: bold; border-radius: 4px; margin: 5px 20px; font-size: 17px;">Deploy Now</a>
 
 This application does a simple redirect based on the clients location.
 


### PR DESCRIPTION
Adds a "Deploy Now" button to Geo-redirect template example.
Testing on prod - I am seeing it in Team account, but my own personal I do not.. I assume this is a group permission thing. 
Before this deploys need to verify that all new and existing users will have access to this template, or it is a broken link.
Also need to clarify with FE team why sign in loses route. seems to always land on /fastedge after a sign in redirect. This is new behaviour since new login form has been deployed.